### PR TITLE
feature: /ignore command

### DIFF
--- a/src/twc-chat.c
+++ b/src/twc-chat.c
@@ -57,6 +57,10 @@ twc_chat_new(struct t_twc_profile *profile, const char *name)
     chat->profile = profile;
     chat->friend_number = chat->group_number = -1;
     chat->nicks = NULL;
+    chat->ids = NULL;
+    chat->completion = NULL;
+    chat->last_search = NULL;
+    chat->prev_comp = NULL;
 
     size_t full_name_size = strlen(profile->name) + 1 + strlen(name) + 1;
     char *full_name = malloc(full_name_size);
@@ -137,6 +141,8 @@ twc_chat_new_group(struct t_twc_profile *profile, int32_t group_number)
         chat->nicklist_group =
             weechat_nicklist_add_group(chat->buffer, NULL, NULL, NULL, true);
         chat->nicks = weechat_list_new();
+        chat->ids = weechat_list_new();
+        chat->completion = weechat_list_new();
 
         weechat_buffer_set(chat->buffer, "nicklist", "1");
     }
@@ -395,6 +401,18 @@ twc_chat_free(struct t_twc_chat *chat)
         weechat_list_remove_all(chat->nicks);
         weechat_list_free(chat->nicks);
     }
+    if (chat->ids)
+    {
+        weechat_list_remove_all(chat->ids);
+        weechat_list_free(chat->ids);
+    }
+    if (chat->completion)
+    {
+        weechat_list_remove_all(chat->completion);
+        weechat_list_free(chat->completion);
+    }
+    free(chat->last_search);
+    free(chat->prev_comp);
     free(chat);
 }
 

--- a/src/twc-chat.c
+++ b/src/twc-chat.c
@@ -281,6 +281,51 @@ twc_chat_search_buffer(struct t_gui_buffer *buffer)
 }
 
 /**
+ * Set a prefix to a nickname in the nicklist of a chat.
+ */
+void
+twc_chat_update_prefix(struct t_twc_chat *chat, const char *id,
+                       const char *prefix, const char *prefix_color)
+{
+    struct t_gui_nick_group *ptr_group = NULL;
+    struct t_gui_nick *ptr_nick = NULL;
+
+    weechat_nicklist_get_next_item(chat->buffer, &ptr_group, &ptr_nick);
+    while (ptr_group || ptr_nick)
+    {
+        if (ptr_nick)
+        {
+            const char *name_field = weechat_nicklist_nick_get_string(
+                chat->buffer, ptr_nick, "name");
+            if (!weechat_strncasecmp(id, name_field + sizeof(char), strlen(id)))
+            {
+                weechat_nicklist_nick_set(chat->buffer, ptr_nick,
+                                          "prefix", prefix);
+                weechat_nicklist_nick_set(chat->buffer, ptr_nick,
+                                          "prefix_color", prefix_color);
+                weechat_nicklist_nick_set(chat->buffer, ptr_nick, "color",
+                                          "default");
+                return;
+            }
+        }
+        weechat_nicklist_get_next_item(chat->buffer, &ptr_group, &ptr_nick);
+    }
+}
+
+/**
+ * Update prefix for a certain nickname structure pointer.
+ */
+void
+twc_chat_update_prefix_by_nick(struct t_gui_buffer *buffer,
+                               struct t_gui_nick *nick, const char *prefix,
+                               const char *prefix_color)
+{
+    weechat_nicklist_nick_set(buffer, nick, "prefix", prefix);
+    weechat_nicklist_nick_set(buffer, nick, "prefix_color", prefix_color);
+    weechat_nicklist_nick_set(buffer, nick, "color", "default");
+}
+
+/**
  * Print a chat message to a chat's buffer.
  */
 void

--- a/src/twc-chat.c
+++ b/src/twc-chat.c
@@ -24,6 +24,7 @@
 #include <tox/tox.h>
 #include <weechat/weechat-plugin.h>
 
+#include "twc-config.h"
 #include "twc-list.h"
 #include "twc-message-queue.h"
 #include "twc-profile.h"
@@ -297,10 +298,13 @@ twc_chat_update_prefix(struct t_twc_chat *chat, const char *id,
         {
             const char *name_field = weechat_nicklist_nick_get_string(
                 chat->buffer, ptr_nick, "name");
-            if (!weechat_strncasecmp(id, name_field + sizeof(char), strlen(id)))
+            size_t short_id_length =
+                weechat_config_integer(twc_config_short_id_size);
+            if (!weechat_strncasecmp(id, name_field + sizeof(char),
+                                     short_id_length))
             {
-                weechat_nicklist_nick_set(chat->buffer, ptr_nick,
-                                          "prefix", prefix);
+                weechat_nicklist_nick_set(chat->buffer, ptr_nick, "prefix",
+                                          prefix);
                 weechat_nicklist_nick_set(chat->buffer, ptr_nick,
                                           "prefix_color", prefix_color);
                 weechat_nicklist_nick_set(chat->buffer, ptr_nick, "color",

--- a/src/twc-chat.h
+++ b/src/twc-chat.h
@@ -56,6 +56,15 @@ twc_chat_search_group(struct t_twc_profile *profile, int32_t group_number,
 struct t_twc_chat *
 twc_chat_search_buffer(struct t_gui_buffer *target_buffer);
 
+void
+twc_chat_update_prefix(struct t_twc_chat *chat, const char *id,
+                       const char *prefix, const char *prefix_color);
+
+void
+twc_chat_update_prefix_by_nick(struct t_gui_buffer *buffer,
+                               struct t_gui_nick *nick, const char *prefix,
+                               const char *prefix_color);
+
 enum t_twc_rc
 twc_chat_set_logging(struct t_twc_chat const *const chat, bool logging);
 

--- a/src/twc-chat.h
+++ b/src/twc-chat.h
@@ -39,6 +39,10 @@ struct t_twc_chat
 
     struct t_gui_nick_group *nicklist_group;
     struct t_weelist *nicks;
+    struct t_weelist *ids;
+    struct t_weelist *completion;
+    char *last_search;
+    char *prev_comp;
 };
 
 struct t_twc_chat *

--- a/src/twc-commands.c
+++ b/src/twc-commands.c
@@ -1437,7 +1437,7 @@ twc_cmd_ignore(const void *pointer, void *data, struct t_gui_buffer *buffer,
 
     const char *id = argv_eol[2];
     struct t_weelist_item *item;
-    item = weechat_list_casesearch(profile->ignores, id);
+    item = twc_is_id_ignored(profile, id);
 
     if (weechat_strcasecmp(argv[1], "add") == 0)
     {

--- a/src/twc-config.c
+++ b/src/twc-config.c
@@ -38,6 +38,7 @@ struct t_config_section *twc_config_section_profile_default = NULL;
 
 struct t_config_option *twc_config_friend_request_message;
 struct t_config_option *twc_config_short_id_size;
+struct t_config_option *twc_config_show_id;
 
 char *twc_profile_option_names[TWC_PROFILE_NUM_OPTIONS] = {
     "save_file",
@@ -374,6 +375,11 @@ twc_config_init()
         NULL, 2, TOX_PUBLIC_KEY_SIZE * 2, "8", NULL, 0,
         twc_config_check_value_callback, NULL, NULL, NULL, NULL, NULL, NULL,
         NULL, NULL);
+    twc_config_show_id = weechat_config_new_option(
+        twc_config_file, twc_config_section_look, "show_id", "boolean",
+        "show short Tox IDs in message logs and presence logs of group chats",
+        NULL, 0, 0, "on", NULL, 0, twc_config_check_value_callback, NULL, NULL,
+        NULL, NULL, NULL, NULL, NULL, NULL);
 }
 
 /**

--- a/src/twc-config.h
+++ b/src/twc-config.h
@@ -24,6 +24,7 @@ struct t_twc_profile;
 
 extern struct t_config_option *twc_config_friend_request_message;
 extern struct t_config_option *twc_config_short_id_size;
+extern struct t_config_option *twc_config_show_id;
 
 enum t_twc_proxy
 {

--- a/src/twc-profile.c
+++ b/src/twc-profile.c
@@ -166,6 +166,7 @@ twc_profile_new(const char *name)
     profile->tox_online = false;
 
     profile->chats = twc_list_new();
+    profile->ignores = weechat_list_new();
     profile->friend_requests = twc_list_new();
     profile->group_chat_invites = twc_list_new();
     profile->message_queues = weechat_hashtable_new(
@@ -247,10 +248,10 @@ twc_tox_new_print_error(struct t_twc_profile *profile,
                            weechat_prefix("error"), options->proxy_host);
             break;
         case TOX_ERR_NEW_PROXY_BAD_PORT:
-            weechat_printf(profile->buffer,
-                           "%scould not load Tox (invalid proxy port: \"%"
-                           PRIu16 "\")",
-                           weechat_prefix("error"), options->proxy_port);
+            weechat_printf(
+                profile->buffer,
+                "%scould not load Tox (invalid proxy port: \"%" PRIu16 "\")",
+                weechat_prefix("error"), options->proxy_port);
             break;
         case TOX_ERR_NEW_PROXY_NOT_FOUND:
             weechat_printf(
@@ -698,6 +699,8 @@ twc_profile_free(struct t_twc_profile *profile)
 
     /* free things */
     twc_chat_free_list(profile->chats);
+    weechat_list_remove_all(profile->ignores);
+    weechat_list_free(profile->ignores);
     twc_friend_request_free_list(profile->friend_requests);
     twc_group_chat_invite_free_list(profile->group_chat_invites);
     twc_tfer_free(profile->tfer);

--- a/src/twc-profile.h
+++ b/src/twc-profile.h
@@ -59,6 +59,7 @@ struct t_twc_profile
     struct t_hook *tox_do_timer;
 
     struct t_twc_list *chats;
+    struct t_weelist *ignores;
     struct t_twc_list *friend_requests;
     struct t_twc_list *group_chat_invites;
     struct t_hashtable *message_queues;

--- a/src/twc-tox-callbacks.c
+++ b/src/twc-tox-callbacks.c
@@ -28,6 +28,7 @@
 #endif /* TOXAV_ENABLED */
 
 #include "twc-chat.h"
+#include "twc-config.h"
 #include "twc-friend-request.h"
 #include "twc-group-invite.h"
 #include "twc-message-queue.h"
@@ -412,6 +413,9 @@ twc_handle_group_message(Tox *tox, int32_t group_number, int32_t peer_number,
 
     char *myname = twc_get_self_name_nt(profile->tox);
     char *name = twc_get_peer_name_nt(profile->tox, group_number, peer_number);
+    char *short_id =
+        twc_get_peer_id_short(profile->tox, group_number, peer_number);
+    char *full_name = twc_get_peer_name_prefixed(short_id, name);
     char *tags = "notify_message";
     char *message_nt = twc_null_terminate(message, length);
 
@@ -425,10 +429,14 @@ twc_handle_group_message(Tox *tox, int32_t group_number, int32_t peer_number,
 
     if (weechat_string_has_highlight(message_nt, myname))
         tags = "notify_highlight";
-    twc_chat_print_message(chat, tags, nick_color, name, message_nt,
-                           message_type);
+    twc_chat_print_message(
+        chat, tags, nick_color,
+        weechat_config_boolean(twc_config_show_id) ? full_name : name,
+        message_nt, message_type);
 
     free(name);
+    free(short_id);
+    free(full_name);
     free(myname);
     free(message_nt);
 }
@@ -456,58 +464,88 @@ twc_group_peer_list_changed_callback(Tox *tox, uint32_t group_number,
 
     struct t_weelist *new_nicks;
     struct t_weelist_item *n;
+    struct t_weelist *new_ids;
+    struct t_weelist_item *id;
 
     npeers = tox_conference_peer_count(profile->tox, group_number, &err);
 
     if (err == TOX_ERR_CONFERENCE_PEER_QUERY_OK)
     {
         new_nicks = weechat_list_new();
+        new_ids = weechat_list_new();
         for (i = 0; i < npeers; i++)
         {
             char *name = twc_get_peer_name_nt(profile->tox, group_number, i);
+            char *id = twc_get_peer_id_short(profile->tox, group_number, i);
             weechat_list_add(new_nicks, name, WEECHAT_LIST_POS_END, NULL);
+            weechat_list_add(new_ids, id, WEECHAT_LIST_POS_END, NULL);
             free(name);
+            free(id);
         }
     }
     else
         return;
 
+    bool changed = false;
+
     /* searching for exits */
     n = weechat_list_get(chat->nicks, 0);
+    id = weechat_list_get(chat->ids, 0);
 
-    while (n)
+    while (id && n)
     {
+        const char *short_id = weechat_list_string(id);
         const char *name = weechat_list_string(n);
-        if (!weechat_list_search(new_nicks, name))
+        if (!weechat_list_search(new_ids, short_id))
         {
-            weechat_printf(chat->buffer, "%s%s just left the group chat",
-                           weechat_prefix("quit"), name);
-            nick = weechat_nicklist_search_nick(chat->buffer,
-                                                chat->nicklist_group, name);
+            char *full_name = twc_get_peer_name_prefixed(short_id, name);
+            nick = weechat_nicklist_search_nick(
+                chat->buffer, chat->nicklist_group, full_name);
             weechat_nicklist_remove_nick(chat->buffer, nick);
+            weechat_printf(
+                chat->buffer, "%s%s just left the group chat",
+                weechat_prefix("quit"),
+                weechat_config_boolean(twc_config_show_id) ? full_name : name);
+            changed = true;
+            free(full_name);
         }
         n = weechat_list_next(n);
+        id = weechat_list_next(id);
     }
 
     /* searching for joins */
     n = weechat_list_get(new_nicks, 0);
+    id = weechat_list_get(new_ids, 0);
 
-    while (n)
+    while (id && n)
     {
+        const char *short_id = weechat_list_string(id);
         const char *name = weechat_list_string(n);
-        if (!weechat_list_search(chat->nicks, name))
+        if (!weechat_list_search(chat->ids, short_id))
         {
-            weechat_printf(chat->buffer, "%s%s just joined the group chat",
-                           weechat_prefix("join"), name);
-            weechat_nicklist_add_nick(chat->buffer, chat->nicklist_group, name,
-                                      NULL, NULL, NULL, 1);
+            char *full_name = twc_get_peer_name_prefixed(short_id, name);
+            weechat_nicklist_add_nick(chat->buffer, chat->nicklist_group,
+                                      full_name, NULL, NULL, NULL, 1);
+            weechat_printf(
+                chat->buffer, "%s%s just joined the group chat",
+                weechat_prefix("join"),
+                weechat_config_boolean(twc_config_show_id) ? full_name : name);
+            changed = true;
+            free(full_name);
         }
         n = weechat_list_next(n);
+        id = weechat_list_next(id);
     }
 
-    weechat_list_remove_all(chat->nicks);
-    weechat_list_free(chat->nicks);
-    chat->nicks = new_nicks;
+    if (changed)
+    {
+        weechat_list_remove_all(chat->nicks);
+        weechat_list_free(chat->nicks);
+        weechat_list_remove_all(chat->ids);
+        weechat_list_free(chat->ids);
+        chat->nicks = new_nicks;
+        chat->ids = new_ids;
+    }
 }
 
 void
@@ -523,10 +561,13 @@ twc_group_peer_name_callback(Tox *tox, uint32_t group_number,
     struct t_gui_nick *nick = NULL;
     const char *prev_name;
     char *name;
+    const char *short_id;
+    char *prev_full_name;
+    char *full_name;
     bool rc;
     TOX_ERR_CONFERENCE_PEER_QUERY err = TOX_ERR_CONFERENCE_PEER_QUERY_OK;
 
-    struct t_weelist_item *n;
+    struct t_weelist_item *n, *id;
 
     npeers = tox_conference_peer_count(profile->tox, group_number, &err);
 
@@ -550,27 +591,40 @@ twc_group_peer_name_callback(Tox *tox, uint32_t group_number,
         twc_group_peer_list_changed_callback(tox, group_number, data);
         return;
     }
-
+    id = weechat_list_get(chat->ids, peer_number);
+    short_id = weechat_list_string(id);
     prev_name = weechat_list_string(n);
+    prev_full_name = twc_get_peer_name_prefixed(short_id, prev_name);
+
     name = twc_null_terminate(pname, pname_len);
+    full_name = twc_get_peer_name_prefixed(short_id, name);
 
     nick = weechat_nicklist_search_nick(chat->buffer, chat->nicklist_group,
-                                        prev_name);
-
+                                        prev_full_name);
     weechat_nicklist_remove_nick(chat->buffer, nick);
+    if (!twc_get_peer_name_count(chat->nicks, prev_name))
+    {
+        nick = weechat_nicklist_search_nick(chat->buffer, chat->nicklist_group,
+                                            prev_name);
+        weechat_nicklist_remove_nick(chat->buffer, nick);
+    }
 
     err = TOX_ERR_CONFERENCE_PEER_QUERY_OK;
     rc = tox_conference_peer_number_is_ours(tox, group_number, peer_number,
                                             &err);
+    bool show_id = weechat_config_boolean(twc_config_show_id);
     if ((err == TOX_ERR_CONFERENCE_PEER_QUERY_OK) && (!rc))
-        weechat_printf(chat->buffer, "%s%s is now known as %s",
-                       weechat_prefix("network"), prev_name, name);
-
+        weechat_printf(
+            chat->buffer, "%s%s is now known as %s", weechat_prefix("network"),
+            show_id ? prev_full_name : prev_name, show_id ? full_name : name);
     weechat_list_set(n, name);
-
+    weechat_nicklist_add_nick(chat->buffer, chat->nicklist_group, full_name,
+                              NULL, NULL, NULL, 1);
     weechat_nicklist_add_nick(chat->buffer, chat->nicklist_group, name, NULL,
-                              NULL, NULL, 1);
+                              NULL, NULL, 0);
 
+    free(prev_full_name);
+    free(full_name);
     free(name);
 }
 

--- a/src/twc-tox-callbacks.c
+++ b/src/twc-tox-callbacks.c
@@ -533,7 +533,8 @@ twc_group_peer_list_changed_callback(Tox *tox, uint32_t group_number,
                                       full_name, NULL, NULL, NULL, 1);
             nick = weechat_nicklist_search_nick(
                 chat->buffer, chat->nicklist_group, full_name);
-            bool ignored = twc_is_id_ignored(profile, short_id);
+            struct t_weelist_item *ignored =
+                twc_is_id_ignored(profile, short_id);
             twc_chat_update_prefix_by_nick(chat->buffer, nick,
                                            ignored ? "-" : " ",
                                            ignored ? "yellow" : "default");
@@ -625,10 +626,10 @@ twc_group_peer_name_callback(Tox *tox, uint32_t group_number,
     weechat_list_set(n, name);
     weechat_nicklist_add_nick(chat->buffer, chat->nicklist_group, full_name,
                               NULL, NULL, NULL, 1);
-    bool ignored = twc_is_id_ignored(profile, short_id);
-    nick = weechat_nicklist_search_nick(chat->buffer, chat->nicklist_group, full_name);
-    twc_chat_update_prefix_by_nick(chat->buffer, nick,
-                                   ignored ? "-" : " ",
+    struct t_weelist_item *ignored = twc_is_id_ignored(profile, short_id);
+    nick = weechat_nicklist_search_nick(chat->buffer, chat->nicklist_group,
+                                        full_name);
+    twc_chat_update_prefix_by_nick(chat->buffer, nick, ignored ? "-" : " ",
                                    ignored ? "yellow" : "default");
     free(prev_full_name);
     free(full_name);

--- a/src/twc-utils.c
+++ b/src/twc-utils.c
@@ -277,6 +277,23 @@ twc_get_next_completion(struct t_weelist *completion_list,
 }
 
 /**
+ * Checks if an ID is ignored.
+ */
+bool
+twc_is_id_ignored(struct t_twc_profile *profile, const char *short_id)
+{
+    struct t_weelist_item *ignore_item;
+    for (ignore_item = weechat_list_get(profile->ignores, 0); ignore_item;
+         ignore_item = weechat_list_next(ignore_item))
+    {
+        if (!weechat_strncasecmp(short_id, weechat_list_string(ignore_item),
+                                 strlen(weechat_list_string(ignore_item))))
+            return true;
+    }
+    return false;
+}
+
+/**
  * reverse the bytes of a 32-bit integer.
  */
 uint32_t

--- a/src/twc-utils.c
+++ b/src/twc-utils.c
@@ -277,9 +277,10 @@ twc_get_next_completion(struct t_weelist *completion_list,
 }
 
 /**
- * Checks if an ID is ignored.
+ * Checks if an ID is ignored. Returns the item from the ignore list if so, NULL
+ * otherwise.
  */
-bool
+struct t_weelist_item *
 twc_is_id_ignored(struct t_twc_profile *profile, const char *short_id)
 {
     struct t_weelist_item *ignore_item;
@@ -287,10 +288,10 @@ twc_is_id_ignored(struct t_twc_profile *profile, const char *short_id)
          ignore_item = weechat_list_next(ignore_item))
     {
         if (!weechat_strncasecmp(short_id, weechat_list_string(ignore_item),
-                                 strlen(weechat_list_string(ignore_item))))
-            return true;
+                                 strlen(short_id)))
+            return ignore_item;
     }
-    return false;
+    return NULL;
 }
 
 /**

--- a/src/twc-utils.h
+++ b/src/twc-utils.h
@@ -21,9 +21,10 @@
 #define TOX_WEECHAT_UTILS_H
 
 #include <stdlib.h>
-
 #include <tox/tox.h>
 #include <weechat/weechat-plugin.h>
+
+#include "twc-profile.h"
 
 void
 twc_hex2bin(const char *hex, size_t size, uint8_t *out);
@@ -73,6 +74,8 @@ twc_starts_with(struct t_weelist *list, const char *search,
 const char *
 twc_get_next_completion(struct t_weelist *completion_list,
                         const char *prev_comp);
+bool
+twc_is_id_ignored(struct t_twc_profile *profile, const char *short_id);
 
 uint32_t
 twc_uint32_reverse_bytes(uint32_t num);

--- a/src/twc-utils.h
+++ b/src/twc-utils.h
@@ -74,7 +74,8 @@ twc_starts_with(struct t_weelist *list, const char *search,
 const char *
 twc_get_next_completion(struct t_weelist *completion_list,
                         const char *prev_comp);
-bool
+
+struct t_weelist_item *
 twc_is_id_ignored(struct t_twc_profile *profile, const char *short_id);
 
 uint32_t

--- a/src/twc-utils.h
+++ b/src/twc-utils.h
@@ -49,6 +49,31 @@ twc_get_self_name_nt(Tox *tox);
 char *
 twc_get_friend_id_short(Tox *tox, int32_t friend_number);
 
+char *
+twc_get_peer_id_short(Tox *tox, uint32_t conference_number,
+                      uint32_t peer_number);
+
+char *
+twc_get_peer_name_prefixed(const char *id, const char *name);
+
+char *
+twc_get_peer_name_prefixed_and_aligned(const char *id, const char *name,
+                                       size_t max);
+
+size_t
+twc_get_max_string_length(struct t_weelist *list);
+
+size_t
+twc_get_peer_name_count(struct t_weelist *list, const char *name);
+
+struct t_weelist *
+twc_starts_with(struct t_weelist *list, const char *search,
+                struct t_weelist *result);
+
+const char *
+twc_get_next_completion(struct t_weelist *completion_list,
+                        const char *prev_comp);
+
 uint32_t
 twc_uint32_reverse_bytes(uint32_t num);
 


### PR DESCRIPTION
This code adds `/ignore` command which is not buffer specific and can be used from any tox plugin's buffer.
```
 [tox]  /ignore  list
                 add <name>
                 del <name>

 ommit messages from people with certain nicks

 list: show the list of ignores
 add: add a nick to the list
 del: delete a nick from the list
```
When you add a nickname to the ignore list using this command it will filter all the messages in group chats you've joined and show only messages from people not it the list.
It indicates muted people in the nicklist of a group chat with "-" prefix (like "devoice" in IRC) and refreshes this prefix after any changes on the ignore list or changing names of peers in groups.
The list of ignores is preserved across restarts by writing it to the file specified in options (`tox.profile.<profile_name>.ignore_file`) and it can be manually saved by issuing `/save` command.

Also I've reverted "clang-format" commit since it leads to multiple merge conflicts and it's way easier to apply it again after merging this branch.
And there's a little fix for #18 that doesn't worth a separate pull request.